### PR TITLE
modify default suffix for clear text cassettes

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,61 @@
+---
+name: dev
+
+on:
+
+  pull_request:
+    branches:
+      - "main"
+
+  push:
+    branches:
+      - "testing"
+
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        required: true
+        default: "warning"
+
+jobs:
+
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    env:
+      using_act: ${{ github.actor == 'nektos/act'}}
+      is_cron: ${{ github.event_name == 'schedule' }}
+
+    steps:
+
+      - name: Checkout.
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.x'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.x'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9.x'
+
+      - name: Make sure path are there also for act shells.
+        if: env.using_act == 'true'
+        run: |
+          echo "export PATH=\"/opt/hostedtoolcache/Python/${{ env.python_version }}/x64:/opt/hostedtoolcache/Python/${{ env.python_version }}/x64/bin:$PATH\"" >> /root/.bashrc
+      - name: Upgrade pip.
+        run: python -m pip install --upgrade pip
+
+      - name: Install poetry and invoke.
+        run: pip install poetry invoke
+
+      - name: Configure poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Install dependencies and test for all supported python version
+        run: inv test-all-python-version

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 .coveralls.yml
 .secrets
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ class MyEncryptedPersister(BaseEncryptedPersister):
 The encrypted persister can now be registered and used:
 
 ```python
+import vcr
+import requests
+
 # create a custom vcr object
 my_vcr = vcr.VCR()
 
@@ -83,7 +86,7 @@ reserving the one with the encrypted persister only for requests resulting in ca
 
 ## Customization
 
-Sometimes it can be handy to inspect the content of a cassette. This can be done even for encrypted cassettes:
+Sometimes it can be handy to inspect the content of a cassette. This can be done even when using encrypted cassettes:
 
 ```python
 class MyEncryptedPersister(BaseEncryptedPersister):
@@ -91,19 +94,18 @@ class MyEncryptedPersister(BaseEncryptedPersister):
     should_output_clear_text_as_well = True
 ```
 
-The persister will output a clear text cassette side by side with the encrypted one. The clear text cassette will
-be saved with a specific file extension (`.clear_text` by default): this will allow to blacklist the extension
-within the version control system to make sure not to share those files. For example for git:
+This persister will output a clear text cassette side by side with the encrypted one. Remember to blacklist all clear
+text cassette in the version control system! For example this will cause git to ignore all `.yaml` file inside a
+cassettes' folder (at any depth):
 
 ```bash
 # file: .gitignore
-*.clear_text
+**/cassettes/**/*.yaml
 ```
-
 Clear text cassettes are only useful for human inspection: the persister will still use only the encrypted ones to
 replay network requests.
 
-If different cassette file extensions are desired, they can be customized:
+If different cassettes file name suffix are desired, they can be customized:
 
 ```python
 class MyEncryptedPersister(BaseEncryptedPersister):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vcrpy-encrypt"
-version = "0.9.0"
+version = "0.9.1"
 description = "Encrypt vcrpy cassettes so they can be safely kept under version control."
 
 license = "GPL-3.0-only"

--- a/tasks.py
+++ b/tasks.py
@@ -118,6 +118,7 @@ def html_cov(c):
 #
 # ACT
 #
+act_dev_ctx = "act-dev-ci"
 act_prod_ctx = "act-prod-ci"
 act_secrets_file = ".secrets"
 
@@ -130,3 +131,13 @@ def act_prod(c, cmd=""):
         c.run(f"docker exec --env-file {act_secrets_file} -it {act_prod_ctx} bash", pty=True)
     elif cmd == "clean":
         c.run(f"docker rm -f {act_prod_ctx}", pty=True)
+
+
+@task
+def act_dev(c, cmd=""):
+    if cmd == "":
+        c.run("act -W .github/workflows/dev.yml", pty=True)
+    elif cmd == "shell":
+        c.run(f"docker exec --env-file {act_secrets_file} -it {act_dev_ctx} bash", pty=True)
+    elif cmd == "clean":
+        c.run(f"docker rm -f {act_dev_ctx}", pty=True)

--- a/vcrpy_encrypt/persister.py
+++ b/vcrpy_encrypt/persister.py
@@ -29,7 +29,7 @@ class BaseEncryptedPersister(ABC):
 
     encryption_key: Union[None, bytes] = None
     should_output_clear_text_as_well: bool = False
-    clear_text_suffix: str = ".clear_text"
+    clear_text_suffix: str = ""
     encoded_suffix: str = ".enc"
 
     @classmethod


### PR DESCRIPTION
It's better not to add a suffix by default, so that editors can still
recognize file extensions like '.yaml'.